### PR TITLE
Set serverVersion back to 4.2.0 to pass regex validation

### DIFF
--- a/lwt/lwt-fixed-100-partitions.yaml
+++ b/lwt/lwt-fixed-100-partitions.yaml
@@ -75,7 +75,7 @@ ensemble:
           spec:
             auth: false
             cassandra:
-              serverVersion: "5.0"
+              serverVersion: "4.2.0"  # Set to 4.2.0 to pass regex validation in cass-operator (still running on Cassandra 5.0 trunk as per below)
               serverImage: "k8ssandra/cass-management-api:5.0-nightly-latest"
               datacenters:
                 - metadata:

--- a/lwt/lwt-fixed-1000-partitions.yaml
+++ b/lwt/lwt-fixed-1000-partitions.yaml
@@ -75,7 +75,7 @@ ensemble:
           spec:
             auth: false
             cassandra:
-              serverVersion: "5.0"
+              serverVersion: "4.2.0"  # Set to 4.2.0 to pass regex validation in cass-operator (still running on Cassandra 5.0 trunk as per below)
               serverImage: "k8ssandra/cass-management-api:5.0-nightly-latest"
               datacenters:
                 - metadata:

--- a/lwt/lwt-fixed-10000-partitions.yaml
+++ b/lwt/lwt-fixed-10000-partitions.yaml
@@ -75,7 +75,7 @@ ensemble:
           spec:
             auth: false
             cassandra:
-              serverVersion: "5.0"
+              serverVersion: "4.2.0"  # Set to 4.2.0 to pass regex validation in cass-operator (still running on Cassandra 5.0 trunk as per below)
               serverImage: "k8ssandra/cass-management-api:5.0-nightly-latest"
               datacenters:
                 - metadata:

--- a/lwt/lwt-rated-100-partitions.yaml
+++ b/lwt/lwt-rated-100-partitions.yaml
@@ -75,7 +75,7 @@ ensemble:
           spec:
             auth: false
             cassandra:
-              serverVersion: "5.0"
+              serverVersion: "4.2.0"  # Set to 4.2.0 to pass regex validation in cass-operator (still running on Cassandra 5.0 trunk as per below)
               serverImage: "k8ssandra/cass-management-api:5.0-nightly-latest"
               datacenters:
                 - metadata:

--- a/lwt/lwt-rated-1000-partitions.yaml
+++ b/lwt/lwt-rated-1000-partitions.yaml
@@ -75,7 +75,7 @@ ensemble:
           spec:
             auth: false
             cassandra:
-              serverVersion: "5.0"
+              serverVersion: "4.2.0"  # Set to 4.2.0 to pass regex validation in cass-operator (still running on Cassandra 5.0 trunk as per below)
               serverImage: "k8ssandra/cass-management-api:5.0-nightly-latest"
               datacenters:
                 - metadata:

--- a/lwt/lwt-rated-10000-partitions.yaml
+++ b/lwt/lwt-rated-10000-partitions.yaml
@@ -75,7 +75,7 @@ ensemble:
           spec:
             auth: false
             cassandra:
-              serverVersion: "5.0"
+              serverVersion: "4.2.0"  # Set to 4.2.0 to pass regex validation in cass-operator (still running on Cassandra 5.0 trunk as per below)
               serverImage: "k8ssandra/cass-management-api:5.0-nightly-latest"
               datacenters:
                 - metadata:


### PR DESCRIPTION
Set serverVersion back to 4.2.0 so that it passes the regex validation in cass-operator as it does not allow 5.x.y versions yet